### PR TITLE
Bugfix/playbook order

### DIFF
--- a/deployments/ecs/1_build_and_push_docker.sh
+++ b/deployments/ecs/1_build_and_push_docker.sh
@@ -30,7 +30,8 @@ aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS 
 
 # 3. Build Docker image
 echo "🔨 Building Docker image..."
-docker build --rm --platform linux/amd64 -t ${ECR_REPO_NAME} .
+# docker build --rm --platform linux/amd64 -t ${ECR_REPO_NAME} .
+docker build --platform linux/amd64 -t ${ECR_REPO_NAME} .
 
 # 4. Tag image for ECR
 echo "🏷️  Tagging image..."

--- a/flows/common/types.py
+++ b/flows/common/types.py
@@ -1,7 +1,9 @@
 import json
+from collections import OrderedDict
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from typing import OrderedDict as TypingOrderedDict
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
@@ -19,18 +21,41 @@ class DOC_STATUS(str, Enum):
     FAILED = "failed"
 
 
+# Playbook definition type, either a dict or a list of tuples both mapping to an OrderDict
+PlaybookDefinition = (
+    TypingOrderedDict[str, dict[str, str | list[str]]]
+    | list[tuple[str, dict[str, str | list[str]]]]
+)
+
+
 class Playbook(BaseModel):
     id: str
     name: str
     version: int = 1
-    definition: dict[str, dict[str, str | list[str]]]
+    definition: PlaybookDefinition
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("definition", mode="before")
+    @classmethod
+    def ensure_ordered_dict(cls, v):
+        if isinstance(v, OrderedDict):
+            return v
+        if isinstance(v, list) or isinstance(v, dict):
+            # Assume list of tuples
+            return OrderedDict(v)
+        else:
+            raise ValueError(f"Invalid type for Playbook definition: {type(v)}")
 
     @classmethod
     def from_json_file(cls, file_path: Path | str):
         fpath = Path(file_path)
         with fpath.open("r", encoding="utf-8") as f:
-            data = json.load(f)
+            data = json.load(f, object_pairs_hook=OrderedDict)
+
+        # Ensure definition is an OrderedDict if loaded from dict
+        if "definition" in data:
+            data["definition"] = OrderedDict(data["definition"])
+
         return cls(**data)
 
 

--- a/flows/common/types.py
+++ b/flows/common/types.py
@@ -36,7 +36,7 @@ class Playbook(BaseModel):
         # The playbook definition can be given as a list of objects, but we always
         # convert to a dict (since python 3.7+ maintains insertion order)
         if isinstance(v, list):
-            return {item.pop("attribute"): item for item in v}
+            return {item["attribute"]: {k: v_ for k, v_ in item.items() if k != "attribute"} for item in v}
         elif isinstance(v, dict):
             return v
         else:

--- a/flows/common/types.py
+++ b/flows/common/types.py
@@ -20,7 +20,6 @@ class DOC_STATUS(str, Enum):
 
 
 # Playbook definition type, either a dict or a list of tuples both mapping to an OrderedDict
-# PlaybookDefinition =
 
 
 class Playbook(BaseModel):

--- a/flows/common/types.py
+++ b/flows/common/types.py
@@ -1,9 +1,7 @@
 import json
-from collections import OrderedDict
 from enum import Enum
 from pathlib import Path
 from typing import Any
-from typing import OrderedDict as TypingOrderedDict
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
@@ -22,27 +20,25 @@ class DOC_STATUS(str, Enum):
 
 
 # Playbook definition type, either a dict or a list of tuples both mapping to an OrderDict
-PlaybookDefinition = (
-    TypingOrderedDict[str, dict[str, str | list[str]]]
-    | list[tuple[str, dict[str, str | list[str]]]]
-)
+# PlaybookDefinition =
 
 
 class Playbook(BaseModel):
     id: str
     name: str
     version: int = 1
-    definition: PlaybookDefinition
+    definition: dict[str, dict[str, Any]] | list[dict[str, Any]]
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("definition", mode="before")
     @classmethod
     def ensure_ordered_dict(cls, v):
-        if isinstance(v, OrderedDict):
+        # The playbook definition can be given as a list of objects, but we always
+        # convert to a dict (since python 3.7+ maintains insertion order)
+        if isinstance(v, list):
+            return {item.pop("attribute"): item for item in v}
+        elif isinstance(v, dict):
             return v
-        if isinstance(v, list) or isinstance(v, dict):
-            # Assume list of tuples
-            return OrderedDict(v)
         else:
             raise ValueError(f"Invalid type for Playbook definition: {type(v)}")
 
@@ -50,11 +46,9 @@ class Playbook(BaseModel):
     def from_json_file(cls, file_path: Path | str):
         fpath = Path(file_path)
         with fpath.open("r", encoding="utf-8") as f:
-            data = json.load(f, object_pairs_hook=OrderedDict)
-
-        # Ensure definition is an OrderedDict if loaded from dict
-        if "definition" in data:
-            data["definition"] = OrderedDict(data["definition"])
+            data = json.load(
+                f,
+            )
 
         return cls(**data)
 

--- a/flows/common/types.py
+++ b/flows/common/types.py
@@ -19,7 +19,7 @@ class DOC_STATUS(str, Enum):
     FAILED = "failed"
 
 
-# Playbook definition type, either a dict or a list of tuples both mapping to an OrderDict
+# Playbook definition type, either a dict or a list of tuples both mapping to an OrderedDict
 # PlaybookDefinition =
 
 

--- a/flows/shrag/playbook.py
+++ b/flows/shrag/playbook.py
@@ -75,11 +75,11 @@ def validate_question_library(q_collection: dict[str, list[QuestionItem]]) -> No
 
 @task
 def build_question_library(
-    playbook: dict[str, dict[str, str | list[str]]],
+    playbook_items: dict[str, dict[str, str | list[str]]],
 ) -> dict[str, list[QuestionItem]]:
-    """Builds the Question Library from the playbook JSON file.
+    """Builds the Question Library from the playbook definition.
 
-    The playbook should have the following structure:
+    The playbook items should have the following structure:
     {
         "<Attribute>": {
             "group": "<Group>",
@@ -100,7 +100,7 @@ def build_question_library(
     """
     # Add the Answer Schema based on the extracted values
     q_collection = defaultdict(list)
-    for i, (attr, p_item) in enumerate(playbook.items()):
+    for i, (attr, p_item) in enumerate(playbook_items.items()):
         # Convert all keys in p_item to snake_case
         p_item_snake = {str_to_snake_case(k): v for k, v in p_item.items()}
 

--- a/flows/shrag/qa.py
+++ b/flows/shrag/qa.py
@@ -247,7 +247,7 @@ class QAgent:
         # Run on the entire Q-collection
         questions_iter = tqdm(q_collection.items()) if pbar else q_collection.items()
         responses = {}
-        # NOTE: Now the Q-collection is a 'dict[list[QuestionItem]]'
+        # NOTE: Now the Q-collection is a 'dict[str, list[QuestionItem]]'
         for _, q_list in questions_iter:
             q = q_list[0]  # Get the first question of the group
             if pbar:

--- a/tests/common/test_types.py
+++ b/tests/common/test_types.py
@@ -1,5 +1,4 @@
 import json
-from collections import OrderedDict
 
 import pytest
 
@@ -64,15 +63,15 @@ def test_playbook_from_json_file(tmp_path):
     assert pb.metadata["foo"] == "bar"
 
 
-def test_playbook_definition_accepts_list_of_tuples_and_preserves_order():
+def test_playbook_definition_accepts_list_of_objects():
     definitions = [
-        ("attrA", {"question": "First question", "valid_answers": ["a1"]}),
-        ("attrB", {"question": "Second question", "valid_answers": ["a2"]}),
-        ("attrC", {"question": "Third question", "valid_answers": ["a3"]}),
+        {"attribute": "attrA", "question": "First question", "valid_answers": ["a1"]},
+        {"attribute": "attrB", "question": "Second question", "valid_answers": ["a2"]},
+        {"attribute": "attrC", "question": "Third question", "valid_answers": ["a3"]},
     ]
     pb = Playbook(id="pb2", name="Tuple Playbook", definition=definitions)
 
-    assert isinstance(pb.definition, OrderedDict)
+    assert isinstance(pb.definition, dict)
     assert list(pb.definition.keys()) == ["attrA", "attrB", "attrC"]
     assert pb.definition["attrB"]["question"] == "Second question"
 
@@ -85,6 +84,6 @@ def test_playbook_definition_accepts_dict_and_preserves_order():
     }
     pb = Playbook(id="pb3", name="Dict Playbook", definition=definitions)
 
-    assert isinstance(pb.definition, OrderedDict)
+    assert isinstance(pb.definition, dict)
     assert list(pb.definition.keys()) == ["attrA", "attrB", "attrC"]
     assert pb.definition["attrB"]["question"] == "B question"

--- a/tests/test_playbook_question_library.py
+++ b/tests/test_playbook_question_library.py
@@ -1,0 +1,76 @@
+from collections import OrderedDict
+
+from flows.shrag.playbook import build_question_library
+
+
+class DummyQuestion:
+    def __init__(self, question, question_type, valid_answers=None):
+        self.question = question
+        self.question_type = question_type
+        self.valid_answers = valid_answers or []
+
+    def __eq__(self, other):
+        return (
+            self.question == other.question
+            and self.question_type == other.question_type
+            and self.valid_answers == other.valid_answers
+        )
+
+
+def test_build_question_library_preserves_order():
+    # Simulate a Playbook.definition as an OrderedDict
+    definition = OrderedDict(
+        [
+            (
+                "zero",
+                {
+                    "group": "",
+                    "question": "Q1",
+                    "question_type": "yes/no",
+                    "valid_answers": ["a"],
+                },
+            ),
+            (
+                "first",
+                {
+                    "group": "g",
+                    "question": "Q1",
+                    "question_type": "yes/no",
+                    "valid_answers": ["a"],
+                },
+            ),
+            (
+                "second",
+                {
+                    "group": "g",
+                    "question": "Q2",
+                    "question_type": "summarisation",
+                    "valid_answers": ["b"],
+                },
+            ),
+            (
+                "third",
+                {
+                    "group": "g",
+                    "question": "Q3",
+                    "question_type": "summarisation",
+                    "valid_answers": ["c"],
+                },
+            ),
+        ]
+    )
+
+    result = build_question_library.fn(definition)
+    # Handle Prefect State or direct dict
+    if hasattr(result, "result"):
+        q_collection = result.result()
+    else:
+        q_collection = result
+
+    print(q_collection)
+    assert list(q_collection.keys()) == ["zero", "g"], (
+        f"Order of keys is not preserved: {q_collection.keys()}"
+    )
+    assert [q.key for q in q_collection["g"]] == ["first", "second", "third"], (
+        f"Order of questions in group 'g' is not preserved: {[q.key for q in q_collection['g']]}"
+    )

--- a/tests/test_playbook_question_library.py
+++ b/tests/test_playbook_question_library.py
@@ -67,7 +67,6 @@ def test_build_question_library_preserves_order():
     else:
         q_collection = result
 
-    print(q_collection)
     assert list(q_collection.keys()) == ["zero", "g"], (
         f"Order of keys is not preserved: {q_collection.keys()}"
     )


### PR DESCRIPTION
Accept playbook definitions as list of items instead of object to avoid Prefect serialisation issues in which keys arrive disordered